### PR TITLE
fix path for bib

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -43,7 +43,7 @@ if (typeof Distribution !== 'undefined') {
 
 // $(function(){
 //   var preEls = Array.prototype.slice.call(document.querySelectorAll("pre"));
-//   preEls.map(function(el) { wpEditor.setup(el, {language: 'webppl'}); });          
+//   preEls.map(function(el) { wpEditor.setup(el, {language: 'webppl'}); });
 // });
 
 
@@ -65,7 +65,7 @@ var textohtml_map = {
   "\\\"{U}": "&Uuml;",
   "\\\"{A}": "&Auml;",
   "\\\"{O}": "&Ouml;",
-  "\\'{E}": "&Eacute;"  
+  "\\'{E}": "&Eacute;"
 };
 
 function textohtml(tex) {
@@ -154,7 +154,7 @@ function format_refp(citation) {
 }
 
 
-$.get("/ESSLLI-2016/bibliography.bib", function (bibtext) {
+$.get("/probLang/bibliography.bib", function (bibtext) {
     $(function () {
         var bibs = doParse(bibtext);
         $.each(


### PR DESCRIPTION
From our email exchange:

MF: The paper references do not show up in my version (e.g., first paragraph at: https://michael-franke.github.io/probLang/chapters/01-introduction.html). I see that there is some JS functionality in ‘assets/js/parse-bibtex.js*’, but it doesn’t work out of the box for me. What to do?

GS: This is an item on my to-do list: the references used to work (some of the early ones still do), but now I’m unable to add new ones, so I’ve been hard-coding the more recent ones. I don’t know what’s wrong. MH, any ideas?

In `main.js`, there is a function that runs the bibtex parser... it was referencing a path which starts with `ESSLLI-2016`, our old project repo. I changed it to `probLang` and this seems to fix the bibliography issue